### PR TITLE
Add PreserveEndOfMonth config for relative dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data-json/
 raw-data/
 .vscode/
+.idea

--- a/config.go
+++ b/config.go
@@ -143,6 +143,10 @@ type Configuration struct {
 	// ReturnTimeAsPeriod returns `Time` as period in date object, if time component is present
 	// in date string. Defaults to false.
 	ReturnTimeAsPeriod bool
+
+	// PreserveEndOfMonth calculates relative month and year dates while preserving the end of
+	// the target month. Ex: "1 month ago" on Oct 31 is Sep 30 instead of Oct 1. Defaults to false.
+	PreserveEndOfMonth bool
 }
 
 // Clone clones the config to a new, separate one.
@@ -164,6 +168,7 @@ func (c Configuration) Clone() *Configuration {
 		RequiredParts:        append([]string{}, c.RequiredParts...),
 		SkipTokens:           append([]string{}, c.SkipTokens...),
 		ReturnTimeAsPeriod:   c.ReturnTimeAsPeriod,
+		PreserveEndOfMonth:   c.PreserveEndOfMonth,
 	}
 }
 
@@ -222,6 +227,7 @@ func (c Configuration) toInternalConfig() *setting.Configuration {
 		SkipTokens:           append([]string{}, c.SkipTokens...),
 		DefaultLanguages:     append([]string{}, c.DefaultLanguages...),
 		ReturnTimeAsPeriod:   c.ReturnTimeAsPeriod,
+		PreserveEndOfMonth:   c.PreserveEndOfMonth,
 	}
 }
 
@@ -237,5 +243,6 @@ func configFromInternal(c *setting.Configuration) *Configuration {
 		SkipTokens:           append([]string{}, c.SkipTokens...),
 		DefaultLanguages:     append([]string{}, c.DefaultLanguages...),
 		ReturnTimeAsPeriod:   c.ReturnTimeAsPeriod,
+		PreserveEndOfMonth:   c.PreserveEndOfMonth,
 	}
 }

--- a/internal/setting/config.go
+++ b/internal/setting/config.go
@@ -45,6 +45,7 @@ type Configuration struct {
 
 	// Others
 	ReturnTimeAsPeriod bool
+	PreserveEndOfMonth bool
 }
 
 func (c Configuration) Clone() *Configuration {
@@ -60,5 +61,6 @@ func (c Configuration) Clone() *Configuration {
 		SkipTokens:           append([]string{}, c.SkipTokens...),
 		DefaultLanguages:     append([]string{}, c.DefaultLanguages...),
 		ReturnTimeAsPeriod:   c.ReturnTimeAsPeriod,
+		PreserveEndOfMonth:   c.PreserveEndOfMonth,
 	}
 }

--- a/parser-relative_test.go
+++ b/parser-relative_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	dps "github.com/markusmobius/go-dateparser"
 	"github.com/markusmobius/go-dateparser/date"
 	"github.com/markusmobius/go-dateparser/internal/strutil"
 	"github.com/markusmobius/go-dateparser/internal/timezone"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -17,6 +18,7 @@ var (
 	relativeTestConfig = dps.Configuration{
 		CurrentTime:        relativeTestNow,
 		ReturnTimeAsPeriod: true,
+		PreserveEndOfMonth: true,
 	}
 	relativeTestParser = dps.Parser{
 		ParserTypes: []dps.ParserType{dps.RelativeTime},
@@ -1111,6 +1113,10 @@ func TestParser_Parse_relative_hasSpecificTime(t *testing.T) {
 		ctTs(fmt.Sprintf("%d months ago", 2008*12+8), ct, tt(1, 10, 4, 13, 15)),
 		ctTs("1 year, 1 month, 1 week, 1 day, 1 hour and 1 minute ago", ct, tt(2009, 4, 26, 12, 14)),
 		ctTs("just now", ct, tt(2010, 6, 4, 13, 15)),
+		ctTs("1 month ago", tt(2024, 10, 31, 14, 0), tt(2024, 9, 30, 14, 0)),
+		ctTs("1 year ago", tt(2024, 2, 29, 14, 0), tt(2023, 2, 28, 14, 0)),
+		ctTs("in 1 year and 1 month", tt(2024, 1, 31, 14, 0), tt(2025, 2, 28, 14, 0)),
+		ctTs("1 month and 5 days ago", tt(2024, 10, 31, 14, 0), tt(2024, 9, 25, 14, 0)),
 
 		// Fractional units
 		ctTs("2.5 hours ago", ct, tt(2010, 6, 4, 10, 45)),


### PR DESCRIPTION
PreserveEndOfMonth calculates relative month and year dates while preserving the end of the target month. Ex: "1 month ago" on Oct 31 is Sep 30 instead of Oct 1.